### PR TITLE
Add S3 mock in tests and log proxy config

### DIFF
--- a/ci/e2e.go
+++ b/ci/e2e.go
@@ -18,14 +18,17 @@ func E2E() error {
 	}
 	defer teardownCompose()
 
-	//wait for startup
-	time.Sleep(time.Second * 2)
+	// wait for startup
+	// TODO: ping s3-mock and wiremock and await startup, it is very slow in the pipeline
+	time.Sleep(time.Second * 10)
 
 	logLevel := seelog.DebugStr
 	requestsPerSecond := 9999999999.0
+	logProxyBaseUrl := "http://someweb.com"
 	gparams := params.Generic{
 		LogLevelFlag:      &logLevel,
 		RequestsPerSecond: &requestsPerSecond,
+		LogProxyBaseUrl:   &logProxyBaseUrl,
 	}
 
 	envAWSEndpointURL := "http://localhost:9090"

--- a/ci/e2e.go
+++ b/ci/e2e.go
@@ -22,16 +22,14 @@ func E2E() error {
 	time.Sleep(time.Second * 2)
 
 	logLevel := seelog.DebugStr
-	skipFileUpload := true
 	requestsPerSecond := 9999999999.0
 	gparams := params.Generic{
 		LogLevelFlag:      &logLevel,
-		SkipFileUpload:    &skipFileUpload,
 		RequestsPerSecond: &requestsPerSecond,
 	}
 
-	envAWSEndpointURL := "http://localhost:8090"
-	envAWSBucket := "random-bucket"
+	envAWSEndpointURL := "http://localhost:9090"
+	envAWSBucket := "node-user-reports"
 	envGithubAccessToken := "github-token"
 	envGithubOwner := "github-owner"
 	envGithubRepository := "github-repo"

--- a/di/di.go
+++ b/di/di.go
@@ -44,7 +44,7 @@ func (c *Container) ConstructServer(gparams params.Generic, eparams params.Envir
 	})
 
 	srvr := server.New(
-		feedback.NewEndpoint(githubReporter, intercomReporter, storage, rateLimiter, gparams.SkipFileUpload),
+		feedback.NewEndpoint(githubReporter, intercomReporter, storage, rateLimiter),
 		infra.NewPingEndpoint(),
 		docs.NewEndpoint(),
 	)

--- a/di/di.go
+++ b/di/di.go
@@ -41,6 +41,7 @@ func (c *Container) ConstructServer(gparams params.Generic, eparams params.Envir
 	intercomReporter := feedback.NewIntercomReporter(&feedback.NewIntercomReporterOpts{
 		Token:           *eparams.EnvIntercomAccessToken,
 		IntercomBaseURL: *eparams.EnvIntercomBaseURL,
+		LogProxyBaseUrl: *gparams.LogProxyBaseUrl,
 	})
 
 	srvr := server.New(

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,11 +1,11 @@
 version: '3.0'
 services:
   wiremock:
-    image: wiremock/wiremock
+    image: wiremock/wiremock:2.32.0
     ports: 
       - '8090:8080'
   s3-mock:
-    image: adobe/s3mock
+    image: adobe/s3mock:2.4.6
     ports:
       - 9090:9090
     environment:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -4,3 +4,9 @@ services:
     image: wiremock/wiremock
     ports: 
       - '8090:8080'
+  s3-mock:
+    image: adobe/s3mock
+    ports:
+      - 9090:9090
+    environment:
+      - initialBuckets=node-user-reports

--- a/e2e/common.go
+++ b/e2e/common.go
@@ -2,11 +2,19 @@ package e2e
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
 	"mime/multipart"
 	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/endpoints"
+	"github.com/aws/aws-sdk-go-v2/aws/external"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/s3manager"
 	"github.com/mysteriumnetwork/feedback/client"
 	"github.com/stretchr/testify/assert"
 )
@@ -24,13 +32,13 @@ type ErrorResponse struct {
 }
 
 // SendReportIntercomIssueRequest send an intercom issue request to the feedback API
-func SendReportIntercomIssueRequest(t *testing.T, payload *client.CreateIntercomIssueRequest, fileContent []byte) *ErrorResponse {
+func SendReportIntercomIssueRequest(t *testing.T, payload *client.CreateIntercomIssueRequest, filename string, fileContent []byte) *ErrorResponse {
 	url := "http://localhost:8080/api/v1/intercom"
 
 	body := new(bytes.Buffer)
 	writer := multipart.NewWriter(body)
 	if len(fileContent) > 0 {
-		part, err := writer.CreateFormFile("file", "example.txt")
+		part, err := writer.CreateFormFile("file", filename)
 		assert.Nil(t, err)
 		_, err = part.Write(fileContent)
 		assert.Nil(t, err)
@@ -70,4 +78,57 @@ func parseResp(t *testing.T, resp *http.Response, obj interface{}) *ErrorRespons
 	}
 
 	return nil
+}
+
+type s3Downloader struct {
+	downloader *s3manager.Downloader
+	client     *s3.Client
+	bucket     string
+}
+
+func newS3Downloader(bucket string) (*s3Downloader, error) {
+	cfg, err := external.LoadDefaultAWSConfig()
+	if err != nil {
+		return nil, fmt.Errorf("could not load AWS configuration: %w", err)
+	}
+	cfg.EndpointResolver = aws.ResolveWithEndpointURL("http://localhost:9090")
+	cfg.Region = endpoints.EuCentral1RegionID
+	s3client := s3.New(cfg)
+	s3client.ForcePathStyle = true
+	downloader := &s3manager.Downloader{
+		S3: s3client,
+	}
+	return &s3Downloader{
+		downloader: downloader,
+		client:     s3client,
+		bucket:     bucket,
+	}, nil
+}
+
+func (s3d *s3Downloader) getFileContent(t *testing.T, filename string) ([]byte, error) {
+	paginator := s3.NewListObjectsV2Paginator(s3d.client.ListObjectsV2Request(&s3.ListObjectsV2Input{
+		Bucket: &s3d.bucket,
+	}))
+	for paginator.Next(context.Background()) {
+		page := paginator.CurrentPage()
+		for _, obj := range page.Contents {
+			fmt.Println(*obj.Key)
+			if strings.Contains(*obj.Key, filename) {
+				buf := aws.NewWriteAtBuffer([]byte{})
+				_, err := s3d.downloader.Download(buf, &s3.GetObjectInput{
+					Bucket: &s3d.bucket,
+					Key:    obj.Key,
+				})
+				if err != nil {
+					return nil, fmt.Errorf("download failed: %w", err)
+				}
+				return buf.Bytes(), nil
+			}
+		}
+	}
+	err := paginator.Err()
+	if err != nil {
+		return nil, fmt.Errorf("pagination error: %w", err)
+	}
+	return nil, fmt.Errorf("file not found")
 }

--- a/feedback/api.go
+++ b/feedback/api.go
@@ -344,23 +344,6 @@ func (e *Endpoint) CreateIntercomIssue(c *gin.Context) {
 		LogURL:       *logURL,
 	}
 
-	// Temporary: we will also create a github issue so logs can be easily accessed from old mmn (disabled in e2e tests)
-	// issueId, err := e.githubReporter.ReportIssue(&Report{
-	// 	UserId:      form.NodeIdentity,
-	// 	Description: form.Description,
-	// 	Email:       form.Email,
-	// 	LogURL:      report.LogURL,
-	// })
-	// if err != nil {
-	// 	apiError := apierror.New("could not report issue to github", err)
-	// 	_ = log.Error(apiError.Wrapped())
-	// 	c.JSON(http.StatusServiceUnavailable, apiError.ToResponse())
-	// 	return
-	// }
-
-	// log.Infof("Created github issue %q from request %+v", issueId, form)
-	// Temporary end
-
 	conversationId, err := e.intercomReporter.ReportIssue(report)
 	if err != nil {
 		apiError := apierror.New("could not create intercom conversation", err)

--- a/feedback/intercom.go
+++ b/feedback/intercom.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"path"
 	"text/template"
 	"time"
 
@@ -84,20 +85,21 @@ Description:
 
 Logs:
 
-{{.LogURL}}
+{{.LogKey}}
 
 `
 
 // ReportIssue creates a issue message for the user in intercom
 func (rep *IntercomReporter) ReportIssue(report *Report) (conversationId string, err error) {
+	key := path.Base(report.LogURL.String())
 	templateOpts := struct {
 		Description,
 		Timestamp,
-		LogURL string
+		LogKey string
 	}{
 		Description: report.Description,
 		Timestamp:   time.Now().String(),
-		LogURL:      report.LogURL.String(),
+		LogKey:      key,
 	}
 	var body bytes.Buffer
 	err = rep.messageTemplate.Execute(&body, templateOpts)

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/magefile/mage v1.8.0
 	github.com/mailru/easyjson v0.7.7
 	github.com/mysteriumnetwork/go-ci v0.0.0-20211124142828-37ca8ff3ef34
-	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.26.1
 	github.com/stretchr/testify v1.7.0
 	github.com/walkerus/go-wiremock v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -539,7 +539,6 @@ github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=

--- a/params/flags_generic.go
+++ b/params/flags_generic.go
@@ -12,13 +12,11 @@ import (
 // Generic represents all the generic parameters
 type Generic struct {
 	LogLevelFlag      *string
-	SkipFileUpload    *bool
 	RequestsPerSecond *float64
 }
 
 // Init initialized the generic parameters with flags
 func (f *Generic) Init() {
 	f.LogLevelFlag = flag.String("log-level", seelog.DebugStr, fmt.Sprintf("Service logging level (%s)", strings.Join(infra.AllLevels, "|")))
-	f.SkipFileUpload = flag.Bool("skipFileUpload", false, "Skips file upload to s3 (useful for test environments)")
 	f.RequestsPerSecond = flag.Float64("requestsPerSecond", 0.0166, "Maximum number of requests per second (default: 1 per minute)")
 }

--- a/params/flags_generic.go
+++ b/params/flags_generic.go
@@ -13,10 +13,12 @@ import (
 type Generic struct {
 	LogLevelFlag      *string
 	RequestsPerSecond *float64
+	LogProxyBaseUrl   *string
 }
 
 // Init initialized the generic parameters with flags
 func (f *Generic) Init() {
 	f.LogLevelFlag = flag.String("log-level", seelog.DebugStr, fmt.Sprintf("Service logging level (%s)", strings.Join(infra.AllLevels, "|")))
 	f.RequestsPerSecond = flag.Float64("requestsPerSecond", 0.0166, "Maximum number of requests per second (default: 1 per minute)")
+	f.LogProxyBaseUrl = flag.String("logProxyBaseUrl", "https://mystnodes.com/support/logs", "A url which serves as proxy for accessing logs easily by support.")
 }


### PR DESCRIPTION
I also removed the use of errors.wrap as it made it difficult to debug and (I think) we don't need go 1.13 compatibility anymore.

The log proxy will be where mystnodes admins will be able to download logs from users, it is just a proxy to our s3. We used to do this through my.mysterium.network by syncing the issues there, this solution will be dumber and simpler.