### PR TITLE
make github use mystnodes links too

### DIFF
--- a/di/di.go
+++ b/di/di.go
@@ -32,9 +32,10 @@ func (c *Container) ConstructServer(gparams params.Generic, eparams params.Envir
 	}
 
 	githubReporter := feedback.NewGithubReporter(&feedback.NewGithubReporterOpts{
-		Token:      *eparams.EnvGithubAccessToken,
-		Owner:      *eparams.EnvGithubOwner,
-		Repository: *eparams.EnvGithubRepository,
+		Token:           *eparams.EnvGithubAccessToken,
+		Owner:           *eparams.EnvGithubOwner,
+		Repository:      *eparams.EnvGithubRepository,
+		LogProxyBaseUrl: *gparams.LogProxyBaseUrl,
 	})
 	rateLimiter := infra.NewRateLimiter(*gparams.RequestsPerSecond)
 


### PR DESCRIPTION
Since old mmn will be discontinued, we need a new way for accessing github logs too.

Signed-off-by: Guillem Bonet <guillem@mysterium.network>